### PR TITLE
feat/14: SignIn 페이지 MVVM -> ReactorKit migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ UI 구성 실험부터 특정 시나리오 기반 기능 검증까지 자유롭�
 - [x] Task B  
 - [x] Task C  
 - [x] Task D  
-- [ ] ReactorKit 전환
+- [x] ReactorKit 전환
 
 <details>
 <summary>Task A</summary><br>
@@ -97,5 +97,8 @@ ReactorKit은 단순한 MVVM의 확장이 아니라,
 
 또한, **TCA(The Composable Architecture)**에 익숙한 개발 경험을 바탕으로  
 ReactorKit을 도입했을 때, 단방향 아키텍처가 실제 개발 및 유지보수에 어떤 이점을 제공하는지 개발하기엔 어떨지 검증해보고자 한다.  
+
+모든 페이지를 다 migration하는 것 보다는, **SignIn 하나만 진행**하고, 이후 있을 몇 개의 뷰들만 Reactor로 진행하여,  
+본 프로젝트에서는 MVVM 방식도 써보고, ReactorKit도 써보며 연습.  
 
 </details>  

--- a/UIKitPlayGround/UIKitPlayGround.xcodeproj/project.pbxproj
+++ b/UIKitPlayGround/UIKitPlayGround.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		B736F17F2EF67634003E6EE7 /* ReactorKit in Frameworks */ = {isa = PBXBuildFile; productRef = B736F17E2EF67634003E6EE7 /* ReactorKit */; };
+		B7BBA0092EF67FA100073EEA /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = B7BBA0082EF67FA100073EEA /* RxRelay */; };
+		B7BBA00B2EF6800D00073EEA /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = B7BBA00A2EF6800D00073EEA /* RxCocoa */; };
 		B7C10E322EF0122200675264 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = B7C10E312EF0122200675264 /* SnapKit */; };
 /* End PBXBuildFile section */
 
@@ -41,7 +43,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B7BBA0092EF67FA100073EEA /* RxRelay in Frameworks */,
 				B736F17F2EF67634003E6EE7 /* ReactorKit in Frameworks */,
+				B7BBA00B2EF6800D00073EEA /* RxCocoa in Frameworks */,
 				B7C10E322EF0122200675264 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -53,6 +57,7 @@
 			isa = PBXGroup;
 			children = (
 				B726FF962EE81AE3002013CD /* UIKitPlayGround */,
+				B7BBA0072EF67FA100073EEA /* Frameworks */,
 				B726FF952EE81AE3002013CD /* Products */,
 			);
 			sourceTree = "<group>";
@@ -63,6 +68,13 @@
 				B726FF942EE81AE3002013CD /* UIKitPlayGround.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		B7BBA0072EF67FA100073EEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -87,6 +99,8 @@
 			packageProductDependencies = (
 				B7C10E312EF0122200675264 /* SnapKit */,
 				B736F17E2EF67634003E6EE7 /* ReactorKit */,
+				B7BBA0082EF67FA100073EEA /* RxRelay */,
+				B7BBA00A2EF6800D00073EEA /* RxCocoa */,
 			);
 			productName = UIKitPlayGround;
 			productReference = B726FF942EE81AE3002013CD /* UIKitPlayGround.app */;
@@ -119,6 +133,7 @@
 			packageReferences = (
 				B7C10E302EF0122200675264 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				B736F17D2EF67634003E6EE7 /* XCRemoteSwiftPackageReference "ReactorKit" */,
+				B7BBA0062EF67F8300073EEA /* XCRemoteSwiftPackageReference "RxSwift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = B726FF952EE81AE3002013CD /* Products */;
@@ -368,6 +383,14 @@
 				minimumVersion = 3.2.0;
 			};
 		};
+		B7BBA0062EF67F8300073EEA /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveX/RxSwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.9.1;
+			};
+		};
 		B7C10E302EF0122200675264 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
@@ -383,6 +406,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B736F17D2EF67634003E6EE7 /* XCRemoteSwiftPackageReference "ReactorKit" */;
 			productName = ReactorKit;
+		};
+		B7BBA0082EF67FA100073EEA /* RxRelay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B7BBA0062EF67F8300073EEA /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxRelay;
+		};
+		B7BBA00A2EF6800D00073EEA /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B7BBA0062EF67F8300073EEA /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
 		};
 		B7C10E312EF0122200675264 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/UIKitPlayGround/UIKitPlayGround/SignIn/SignInCoordinator.swift
+++ b/UIKitPlayGround/UIKitPlayGround/SignIn/SignInCoordinator.swift
@@ -5,9 +5,12 @@
 //  Created by 김동준 on 12/13/25
 //
 
+import ReactorKit
+
 final class SignInCoordinator: BaseCoordinator {
     private let navigationController: BaseNavigationController
     weak var delegate: SignInCoordinatorDelegate?
+    private var disposeBag = DisposeBag()
     
     init(navigationController: BaseNavigationController) {
         self.navigationController = navigationController
@@ -19,17 +22,22 @@ final class SignInCoordinator: BaseCoordinator {
     }
     
     override func start() {
-        let viewModel = SignInViewModel()
-        let viewController = SignInViewController(viewModel: viewModel)
-        viewModel.onOutput = { [weak self] output in
-            guard let self = self else { return }
-            switch output {
-            case .onChangeMain:
-                self.delegate?.onDidLogIn(self)
-            case .onPushSignInDetail:
-                showSignInDetail()
-            }
-        }
+        let reactor = SignInReactor()
+        let viewController = SignInViewController(reactor: reactor)
+        
+        reactor.route
+            .subscribe(
+                onNext: { [weak self ] route in
+                    guard let self = self else { return }
+                    switch route {
+                    case .changeMain:
+                        self.delegate?.onDidLogIn(self)
+                    case .pushSignInDetail:
+                        showSignInDetail()
+                    }
+                }
+            )
+            .disposed(by: disposeBag)
 
         navigationController.setViewControllers([viewController], animated: false)
     }

--- a/UIKitPlayGround/UIKitPlayGround/SignIn/SignInReactor.swift
+++ b/UIKitPlayGround/UIKitPlayGround/SignIn/SignInReactor.swift
@@ -1,0 +1,58 @@
+//
+//  SignInReactor.swift
+//  UIKitPlayGround
+//
+//  Created by 김동준 on 12/20/25
+//
+
+import ReactorKit
+import RxRelay
+
+class SignInReactor: Reactor {
+    struct State {
+        
+    }
+    
+    enum Mutation {
+        
+    }
+    
+    enum Action {
+        case mainbuttonTapped
+        case kakaoButtonTapped
+        case appleButtonTapped
+    }
+    
+    enum Route {
+        case changeMain
+        case pushSignInDetail
+    }
+    
+    let initialState: State = .init()
+    let route = PublishRelay<Route>()
+    
+    init() {
+        print("⭕ SignInReactor init!")
+    }
+    
+    deinit {
+        print("❎ SignInReactor deinit!")
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .mainbuttonTapped:
+            route.accept(.changeMain)
+            return .empty()
+        case .kakaoButtonTapped:
+            route.accept(.pushSignInDetail)
+            return .empty()
+        case .appleButtonTapped:
+            return .empty()
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        return state
+    }
+}

--- a/UIKitPlayGround/UIKitPlayGround/SignIn/SignInViewController.swift
+++ b/UIKitPlayGround/UIKitPlayGround/SignIn/SignInViewController.swift
@@ -6,16 +6,18 @@
 //
 
 import UIKit
+import ReactorKit
+import RxCocoa
 
-class SignInViewController: UIViewController {
-    private let viewModel: SignInViewModel
+class SignInViewController: UIViewController, View {
+    var disposeBag = DisposeBag()
     
     deinit {
         print("❎ SignInViewController deinit!")
     }
     
-    init(viewModel: SignInViewModel) {
-        self.viewModel = viewModel
+    init(reactor: SignInReactor) {
+        defer { self.reactor = reactor }
         super.init(nibName: nil, bundle: nil)
         print("⭕ SignInViewController init!")
     }
@@ -58,7 +60,6 @@ class SignInViewController: UIViewController {
 
         setupLayout()
         setBottomButtonLayout()
-        setupAction()
     }
     
     private func setupLayout() {
@@ -98,22 +99,20 @@ class SignInViewController: UIViewController {
         }
     }
     
-    private func setupAction() {
-        button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
-        kakaoButton.addAction(
-            UIAction { [weak self] _ in
-                guard let self = self else { return }
-                self.viewModel.send(.kakaoButtonTapped)
-            }, for: .touchUpInside
-        )
-        appleButton.addTarget(self, action: #selector(appleButtonTapped), for: .touchUpInside)
-    }
-    
-    @objc private func buttonTapped() {
-        viewModel.send(.buttonTapped)
-    }
-    
-    @objc private func appleButtonTapped() {
-        viewModel.send(.appleButtonTapped)
+    func bind(reactor: SignInReactor) {
+        button.rx.tap
+            .map { SignInReactor.Action.mainbuttonTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        kakaoButton.rx.tap
+            .map { SignInReactor.Action.kakaoButtonTapped }
+            .bind(to: reactor.action )
+            .disposed(by: disposeBag)
+        
+        appleButton.rx.tap
+            .map { SignInReactor.Action.appleButtonTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
기존 MVVM 방식으로 구현됐던 SignIn을 ReactorKit을 사용해서
TCA와 유사한 단방향 방식으로 수정.

그와 관련된 코드 모두 수정

+ ReactorKit + RxSwift 를 이번 브랜치에 도입했기 때문에, SPM 을 통해 추가하였음.